### PR TITLE
Remove `wp-blocks` style dep

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -25,7 +25,7 @@ function inhabitent_blocks_block_assets() {
 	wp_enqueue_style(
 		'inhabitent-blocks-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array() // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 }


### PR DESCRIPTION
Remove `wp-blocks` as stylesheet dependency resolves #3. Leaving an empty array to avoid confusion if uncommenting and passing stylesheet version as incorrect param.